### PR TITLE
undo

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "bluebird": "^2.9.16",
+    "deep-equal": "^1.0.0",
     "keycode": "^2.1.0",
     "lodash": "^3.6.0",
     "observe": "^1.0.2",


### PR DESCRIPTION
Implementation was trying to have an undo stack for each active
instance of animus, and then, when getting the `onChanged` event
from chrome.storage.sync, check if it's a change or an instance
doing undo.

However, without uglier hacks, it's not possible to tell whether
a createX+deleteX is different from a createX+undo.

The way to go is to have a single undo stack which is shared on
sync storage, which solves some of the ugly case scenarios.

This implementation works without gotchas when using a single instance of animus at a time, or not relying on too many undos when using multiple instance of animus at the same time. Since it can help some people recover entries deleted by accident, I'll be merging this even if it does not work on all cases.